### PR TITLE
Removing undefinded function psc-ide-meta.

### DIFF
--- a/psc-ide.el
+++ b/psc-ide.el
@@ -69,7 +69,7 @@
     (sorted t)
 
     (annotation (psc-ide-annotation arg))
-    (meta (psc-ide-meta arg))
+    (meta arg)
 ))
 
 (defun psc-ide-server (dir-name)


### PR DESCRIPTION
Someone has commited undefined function psc-ide-meta. Current version of psc-ide-emacs can't complete symbols with it.