### PR TITLE
remove meta case for company

### DIFF
--- a/psc-ide.el
+++ b/psc-ide.el
@@ -84,7 +84,6 @@
     (sorted t)
 
     (annotation (psc-ide-annotation arg))
-    (meta (psc-ide-meta arg))
 ))
 
 (defun psc-ide-server-start (dir-name)


### PR DESCRIPTION
The displaying of the type signature happens in company-psc-ide-frontend