### PR TITLE
Load cl-lib.el for using its macros

### DIFF
--- a/psc-ide-backported.el
+++ b/psc-ide-backported.el
@@ -20,7 +20,7 @@ May return a qualified name."
         (skip-chars-backward " \t"))
 
     (let ((case-fold-search nil))
-      (multiple-value-bind (start end)
+      (cl-multiple-value-bind (start end)
           (if (looking-at "\\s_")
               (list (progn (skip-syntax-backward "_") (point))
                     (progn (skip-syntax-forward "_") (point)))

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -7,7 +7,7 @@
 ;;            Christoph Hegemann
 ;; Homepage : https://github.com/epost/psc-ide-emacs
 ;; Version  : 0.1.0
-;; Package-Requires: ((dash "2.11.0") (company "0.8.7"))
+;; Package-Requires: ((dash "2.11.0") (company "0.8.7") (cl-lib "0.5"))
 ;; Keywords : languages
 
 ;;; Commentary:
@@ -22,6 +22,7 @@
 ;; Imports
 
 (require 'company)
+(require 'cl-lib)
 (require 'psc-ide-backported)
 (require 'psc-ide-protocol)
 
@@ -74,7 +75,7 @@
   "The psc-ide backend for 'company-mode'."
   (interactive (list 'interactive))
 
-  (case command
+  (cl-case command
     (interactive (company-begin-backend 'company-psc-ide-backend))
 
     (prefix (and (eq major-mode 'purescript-mode)
@@ -169,7 +170,7 @@
 (setq company-tooltip-align-annotations t)
 
 (defun company-psc-ide-frontend (command)
-  (case command
+  (cl-case command
     (post-command (and (eq major-mode 'purescript-mode)
                        (message
                         (get-text-property 0 :type


### PR DESCRIPTION
There are many byte-compile warnings by not loading cl-lib.el(cl.el).

```
In company-psc-ide-backend:
psc-ide.el:75:23:Warning: misplaced interactive spec: `(interactive
    (company-begin-backend (quote company-psc-ide-backend)))'

In end of data:
psc-ide.el:189:1:Warning: the following functions are not known to be defined: case, prefix,
    candidates, sorted, annotation, post-command

In psc-ide-ident-pos-at-point:
psc-ide-backported.el:23:35:Warning: reference to free variable `end'
psc-ide-backported.el:33:20:Warning: reference to free variable `start'
psc-ide-backported.el:40:31:Warning: assignment to free variable `end'
psc-ide-backported.el:50:17:Warning: assignment to free variable `start'

In end of data:
psc-ide-backported.el:55:1:Warning: the following functions are not known to be defined:
    multiple-value-bind, start
```

And it is better to use cl-lib.el rather than cl.el