### PR TITLE
Allow psc-ide-server to be started using stack.

### DIFF
--- a/psc-ide.el
+++ b/psc-ide.el
@@ -130,10 +130,9 @@
 
 (defun psc-ide-server-start-impl (dir-name)
   "Start psc-ide-server."
-  (start-process "*psc-ide-server*"
-                 "*psc-ide-server*"
-                 psc-ide-server-executable
-                 "-d" dir-name))
+  (apply #'start-process `("*psc-ide-server*" "*psc-ide-server*"
+                           ,@(split-string psc-ide-server-executable)
+                           "-d" ,dir-name)))
 
 (defun psc-ide-load-module-impl (module-name)
   "Load PureScript module and its dependencies."


### PR DESCRIPTION
This allows me to enter "stack exec -- psc-ide-server"  for the psc-ide-server-executable variable.  As it is now I get an error when I tried to change those to use the stack commands described in the psc-ide README.