### PR TITLE
Context aware completions

### DIFF
--- a/psc-ide-protocol.el
+++ b/psc-ide-protocol.el
@@ -24,9 +24,9 @@
 (defun psc-ide-command-complete (filters matcher)
   (json-encode
    (list :command "complete"
-         :params (list
-                  :filters filters
-                  :matcher matcher))))
+         :params (-filter #'identity
+                          `(,@(when filters (list :filters filters))
+                            ,@(when matcher (list :matcher matcher)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -130,10 +130,9 @@
 
 (defun psc-ide-server-start-impl (dir-name)
   "Start psc-ide-server."
-  (start-process "*psc-ide-server*"
-                 "*psc-ide-server*"
-                 psc-ide-server-executable
-                 "-d" dir-name))
+  (apply #'start-process `("*psc-ide-server*" "*psc-ide-server*"
+                           ,@(split-string psc-ide-server-executable)
+                           "-d" ,dir-name)))
 
 (defun psc-ide-load-module-impl (module-name)
   "Load PureScript module and its dependencies."

--- a/test/psc-ide-test.el
+++ b/test/psc-ide-test.el
@@ -1,3 +1,21 @@
+(require 'psc-ide)
+
+(defconst psc-ide-test-example-imports "
+module Main where
+
+import Prelude
+
+import Control.Monad.Aff (Aff(), runAff, later')
+import Control.Monad.Eff (Eff())
+import Control.Monad.Eff.Exception (throwException)
+import Halogen
+
+import Halogen.Util (appendToBody, onLoad)
+import 		qualified Halogen.HTML.Indexed 		as 	Hd
+import qualified Halogen.HTML.Properties.Indexed as P
+
+")
+
 (ert-deftest psc-ide-show-type-impl-test ()
   (with-mock
    (mock (psc-ide-send *) => "{\"result\":[{\"type\":\"Show-Type\",\"module\":\"Module\"}],\"resultType\":\"success\"}\n")
@@ -7,3 +25,66 @@
   (with-mock
    (mock (psc-ide-send *) => "{\"result\":[],\"resultType\":\"success\"}\n")
    (should (not (psc-ide-show-type-impl "something")))))
+
+
+;; Module  import parsing tests
+
+(ert-deftest test-get-import-matches-in-buffer-should-return-all-imports ()
+  (with-temp-buffer
+    (insert psc-ide-test-example-imports)
+    (goto-char 0)
+    (let ((matches (psc-ide-parse-imports-in-buffer)))
+      (should (= 8 (length matches))))))
+
+(defun test-import (import name as exposing)
+    (string-match psc-ide-import-regex import)
+    (let* ((import (psc-ide-get-import-from-match-data import)))
+      (should (equal (assoc 'module import) (cons 'module name)))
+      (should (equal (assoc 'alias import) (cons 'alias as)))
+      (should (equal (assoc 'exposing import) (cons 'exposing exposing)))))
+
+(ert-deftest test-get-import-from-match-data-full ()
+  (test-import "import qualified Mod.SubMod as El (foo, bar)"
+               "Mod.SubMod"
+               "El"
+               '("foo" "bar")))
+
+(ert-deftest test-match-import-single-module ()
+  (test-import "import Foo" "Foo" nil ()))
+
+(ert-deftest test-match-import-with-alias ()
+  (test-import "import qualified Foo as F" "Foo" "F" nil))
+
+(ert-deftest test-match-import-with-single-expose ()
+  (test-import "import Foo (test)" "Foo" nil '("test")))
+
+(ert-deftest test-match-import-with-multiple-exposings-tight ()
+  (test-import "import Foo (test1,test2)" "Foo" nil '("test1" "test2")))
+
+(ert-deftest test-match-import-with-multiple-exposings-loose ()
+  (test-import "import Foo ( test1 , test2 )" "Foo" nil '("test1" "test2")))
+
+(ert-deftest test-match-import-with-alias+multiple-exposings-tight ()
+  (test-import "import qualified Foo as F (test1,test2)" "Foo" "F" '("test1" "test2")))
+
+(ert-deftest test-match-import-with-alias+multiple-exposings-loose ()
+  (test-import
+   "import qualified Foo as F ( test1 , test2 )"
+   "Foo"
+   "F"
+   '("test1" "test2")))
+
+
+;; Prefix tets
+
+(ert-deftest test-prefix-non-qualified ()
+  (with-temp-buffer
+    (insert "test")
+    (let ((symbol (psc-ide-ident-at-point)))
+      (should (equal symbol "test")))))
+
+(ert-deftest text-prefix-qualified ()
+  (with-temp-buffer
+    (insert "test.a")
+    (let ((symbol (psc-ide-ident-at-point)))
+      (should (equal symbol "test.a")))))


### PR DESCRIPTION
This should fix issued #7 and #10 

The imports are parsed on the init function when company is initialized and that is used later to create a module filter for the psc-ide command.
I added some test cases but some more manual testing probably wouldn't hurt. 

The one thing I couldn't figure out is how to show the completions without the qualifier prepended. For example, if I typed H.f then the completions would show "H.fob, H.foo, etc" instead of just "fob, foo".  Otherwise when the completion is expanded the qualifier would get replaced. 

Please test it out and let me know what you think.