### PR TITLE
Rebuild commands

### DIFF
--- a/README.org
+++ b/README.org
@@ -17,7 +17,7 @@
 ** Configuration
 
    Add the following to your =~/.emacs=:
-   
+
    #+BEGIN_SRC elisp
 
    ;; specify path to the 'psc-ide' executable
@@ -38,12 +38,17 @@
 *** Get completions from the modules you imported while you type (through ~company-mode~)
     [[http://i.imgur.com/8WnRh0s.gif]]
 
-*** Get completions from all modules in your project ~C-<SPC>~ (through ~company-mode~)
+*** Get completions from all modules in your project with ~company-complete~
+    This was bound to ~C-SPC~ in earlier versions but was too intrusive for
+    usual emacs users so you'll have to bind it to a key of choice.
+
+    eg. ~(global-set-key (kbd "C-SPC") 'company-complete)~
+
     [[http://i.imgur.com/LR69MdN.gif]]
 
 *** Show type for identifier under cursor ~C-c C-t~
     [[http://i.imgur.com/A8cXe9t.gif]]
-    
+
 *** Add a clause for the function definition under cursor ~C-c C-t~
     [[http://i.imgur.com/VNeC3z8.gif]]
 
@@ -62,13 +67,19 @@
     #+BEGIN_SRC elisp
     (customize-set-variable 'psc-ide-add-import-on-completion nil)
     #+END_SRC
-    
+
     [[http://i.imgur.com/r6rl2lT.gif]]
-    
+
+*** Rebuild the current module and get quick error reporting ~C-c C-b~
+    If you set ~(custom-set-variables 'psc-ide-rebuild-on-save t)~ psc-ide will
+    try to rebuild your module on every save.
+
+    [[http://i.imgur.com/c0L6C4B.gif]]
+
 *** Keybindings
-    
+
    | Key         | Function               |
-   |-------------+------------------------+
+   |-------------+------------------------|
    | ~C-c C-s~   | ~psc-ide-server-start~ |
    | ~C-c C-q~   | ~psc-ide-server-quit~  |
    | ~C-c C-l~   | ~psc-ide-load-all~     |
@@ -76,6 +87,5 @@
    | ~C-c C-c~   | ~psc-ide-case-split~   |
    | ~C-c C-i~   | ~psc-ide-add-import~   |
    | ~C-c C-t~   | ~psc-ide-show-type~    |
+   | ~C-c C-b~   | ~psc-ide-rebuild~      |
    | ~C-c C-S-l~ | ~psc-ide-load-module~  |
-   | ~C-<SPC>~   | ~company-complete~     |
- 

--- a/psc-ide-protocol.el
+++ b/psc-ide-protocol.el
@@ -57,6 +57,13 @@
                   :importCommand (list
                                   :importCommand "addImport"
                                   :identifier identifier)))))
+
+(defun psc-ide-command-rebuild (&optional filepath outpath)
+  (json-encode
+   (list :command "rebuild"
+         :params (list
+                  :file (or filepath (buffer-file-name (current-buffer)))
+                  :outpath outpath))))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; Protocol utilities.

--- a/psc-ide-protocol.el
+++ b/psc-ide-protocol.el
@@ -23,12 +23,13 @@
                   :filters filters
                   :search search ))))
 
-(defun psc-ide-command-complete (filters &optional matcher)
+(defun psc-ide-command-complete (filters &optional matcher module)
   (json-encode
    (list :command "complete"
          :params (-filter #'identity
                           `(,@(when filters (list :filters filters))
-                            ,@(when matcher (list :matcher matcher)))))))
+                            ,@(when matcher (list :matcher matcher))
+                            ,@(when module (list :currentModule module)))))))
 
 (defun psc-ide-command-case-split (line begin end type)
   (json-encode
@@ -63,6 +64,7 @@
    (list :command "rebuild"
          :params (list
                   :file (or filepath (buffer-file-name (current-buffer)))
+                  :cacheSuccess t
                   :outpath outpath))))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -78,6 +78,11 @@
   :group 'psc-ide
   :type 'boolean)
 
+(defcustom psc-ide-rebuild-on-save "t"
+  "Whether to use the compilation window as a popup buffer to show errors"
+  :group 'psc-ide
+  :type 'boolean)
+
 (defconst psc-ide-import-regex
   (rx (and line-start "import" (1+ space) (opt (and "qualified" (1+ space)))
         (group (and (1+ (any word "."))))
@@ -93,6 +98,14 @@
             (set 'psc-ide-buffer-import-list
                  (psc-ide-parse-imports-in-buffer)))
           nil t)
+
+(defun psc-ide-rebuild-on-save-hook()
+  "Rebuilds the current module on safe"
+  (when (eq major-mode 'purescript-mode)
+    (psc-ide-rebuild)))
+
+(when psc-ide-rebuild-on-save
+  (add-hook 'after-save-hook 'psc-ide-rebuild-on-save-hook))
 
 (defun psc-ide-init ()
   (interactive)
@@ -197,8 +210,40 @@
 (defun psc-ide-rebuild ()
   "Rebuild the current module"
   (interactive)
-  (message (psc-ide-unwrap-result (json-read-from-string
-                                   (psc-ide-send (psc-ide-command-rebuild))))))
+  (let* ((res (json-read-from-string
+               (psc-ide-send (psc-ide-command-rebuild))))
+         (is-success (string= "success" (cdr (assoc 'resultType res))))
+         (result (cdr (assoc 'result res))))
+
+    (if (not is-success)
+        (let* ((first-error (aref result 0)))
+          (psc-ide-display-rebuild-error (psc-ide-pretty-json-error first-error))))
+    (if (<= (length result) 0)
+        (progn
+          (delete-windows-on (get-buffer-create "*psc-ide-rebuild*"))
+          (message "OK"))
+      (let* ((first-warning (aref result 0)))
+        (psc-ide-display-rebuild-error (psc-ide-pretty-json-error first-warning))))))
+
+(defun psc-ide-display-rebuild-error (err)
+  (with-current-buffer (get-buffer-create "*psc-ide-rebuild*")
+    (compilation-mode)
+    (read-only-mode -1)
+    (erase-buffer)
+    (insert err)
+    (read-only-mode 1))
+  (display-buffer "*psc-ide-rebuild*")
+  (set-window-point (get-buffer-window "*psc-ide-rebuild*") (point-min)))
+
+(defun psc-ide-pretty-json-error (first-error)
+  (let ((err-message (cdr (assoc 'message first-error)))
+        (err-filename (cdr (assoc 'filename first-error)))
+        (err-position (cdr (assoc 'position first-error))))
+    (if (not err-position)
+        err-message
+      (let ((err-column (cdr (assoc 'startColumn err-position)))
+            (err-line (cdr (assoc 'startLine err-position))))
+        (concat err-filename ":" (number-to-string err-line) ":" (number-to-string err-column) ":" "\n" err-message)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -194,6 +194,12 @@
   (interactive)
   (psc-ide-add-import-impl (psc-ide-ident-at-point)))
 
+(defun psc-ide-rebuild ()
+  "Rebuild the current module"
+  (interactive)
+  (message (psc-ide-unwrap-result (json-read-from-string
+                                   (psc-ide-send (psc-ide-command-rebuild))))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; Non-interactive.

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -78,8 +78,9 @@
   :group 'psc-ide
   :type 'boolean)
 
-(defcustom psc-ide-rebuild-on-save "t"
-  "Whether to use the compilation window as a popup buffer to show errors"
+(defcustom psc-ide-rebuild-on-save nil
+  "Whether to rebuild files on save and display errors/warnings
+in a buffer"
   :group 'psc-ide
   :type 'boolean)
 

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -45,7 +45,7 @@
             (define-key map (kbd "C-c C-c") 'psc-ide-case-split)
             (define-key map (kbd "C-c C-i") 'psc-ide-add-import)
             (define-key map (kbd "C-c C-t") 'psc-ide-show-type)
-            (define-key map (kbd "C-<SPC>") 'company-complete)
+            (define-key map (kbd "C-c C-b") 'psc-ide-rebuild)
             map))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -450,7 +450,8 @@ Returns an plist with the search, qualifier, and relevant modules."
                      (psc-ide-send (psc-ide-command-complete
                                       (if nofilter
                                           (vector prefilter) ;; (vconcat nil) = []
-                                        (vconcat filters))))))))
+                                        (vconcat filters))
+                                      nil (psc-ide-get-module-name)))))))
       (->> result
            (remove-if-not
             (lambda (x)


### PR DESCRIPTION
Adds rebuild commands for psc-ide, also adds fields for the upcoming rebuild cache functionality which just get ignored by older psc-ide versions.

Also removes the `C-SPC` keybinding as I find that too intrusive to emacs users.