### PR TITLE
Async network

### DIFF
--- a/psc-ide.el
+++ b/psc-ide.el
@@ -326,16 +326,11 @@ use when the search used was with `string-match'."
                :family 'ipv4
                :host "localhost"
                :service 4242
-               :filter (wrap-psc-ide-callback callback))))
+               :filter (-partial 'wrap-psc-ide-callback callback))))
     (process-send-string proc (s-prepend cmd "\n"))))
 
-(defun wrap-psc-ide-callback (callback)
+(defun wrap-psc-ide-callback (callback proc output)
   "Wraps a function that expects a parsed psc-ide response"
-  (let ((cb callback))
-    (lambda (proc output)
-      (impl cb proc output))))
-
-(defun impl (callback proc output)
   (let ((parsed (condition-case err
                     (json-read-from-string output)
                   (json-readtable-error

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -482,11 +482,6 @@ Returns an plist with the search, qualifier, and relevant modules."
         (list 'search search 'qualifier nil 'modules (psc-ide-filter-bare-imports imports))
       (list 'search search 'qualifier qualifier 'modules (psc-ide-filter-imports-by-alias imports qualifier)))))
 
-
-(defun psc-ide-make-module-filter (type modules)
-  (list :filter type
-        :params (list :modules modules)))
-
 (defun psc-ide-filter-results-p (imports search qualifier result)
   (let ((completion (cdr (assoc 'identifier result)))
         (type (cdr (assoc 'type result)))
@@ -519,7 +514,7 @@ Returns an plist with the search, qualifier, and relevant modules."
                                                       :qualifier qualifier) str)
                        str))
            (prefilter (psc-ide-filter-prefix prefix))
-           (filters (-non-nil (list (psc-ide-make-module-filter "modules" moduleFilters) prefilter)))
+           (filters (-non-nil (list (psc-ide-filter-modules moduleFilters) prefilter)))
            (result (psc-ide-unwrap-result
                     (psc-ide-send-sync
                      (psc-ide-command-complete
@@ -581,7 +576,7 @@ Returns NIL if the type of IDENT is not found."
          (moduleFilters (plist-get pprefix 'modules))
          (resp (psc-ide-send-sync
                 (psc-ide-command-show-type
-                 (vector (psc-ide-make-module-filter "modules" moduleFilters))
+                 (vector (psc-ide-filter-modules moduleFilters))
                  search)))
          (result (psc-ide-unwrap-result resp)))
     (when (not (zerop (length result)))

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -215,7 +215,7 @@ in a buffer"
   (interactive)
   (psc-ide-add-import-impl (psc-ide-ident-at-point)))
 
-(defun psc-ide-rebuild (res)
+(defun psc-ide-rebuild ()
   "Rebuild the current module"
   (interactive)
   (let* ((res (psc-ide-send-sync (psc-ide-command-rebuild)))
@@ -335,7 +335,7 @@ use when the search used was with `string-match'."
           ;; Wait for the process in a blocking manner for a maximum of 2
           ;; seconds
           (accept-process-output proc 2)
-          (-first-item (s-lines (buffer-string))))
+          (json-read-from-string (-first-item (s-lines (buffer-string)))))
       (error
        (error
         (s-join " "

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -543,8 +543,7 @@ Returns NIL if the type of SEARCH is not found."
 (defun psc-ide-string-fontified (str)
   "Takes a string and returns it with syntax highlighting."
   (with-temp-buffer
-    (when (fboundp 'purescript-mode)
-      (purescript-mode))
+    (turn-on-purescript-font-lock)
     (insert str)
     (font-lock-fontify-buffer)
     (buffer-string)))

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -7,7 +7,7 @@
 ;;            Christoph Hegemann
 ;; Homepage : https://github.com/epost/psc-ide-emacs
 ;; Version  : 0.1.0
-;; Package-Requires: ((dash "2.11.0") (company "0.8.7") (cl-lib "0.5") (s "1.10.0"))
+;; Package-Requires: ((dash "2.12.1") (dash-functional "1.2.0") (company "0.8.7") (cl-lib "0.5") (s "1.10.0"))
 ;; Keywords : languages
 
 ;;; Commentary:
@@ -303,7 +303,6 @@ use when the search used was with `string-match'."
          result)
     (push `(module . ,(match-string-no-properties 1 string)) result)
     (push `(alias . ,(match-string-no-properties 2 string)) result)
-    (push `(exposing . ,(psc-ide-parse-exposed (match-string-no-properties 3 string))) result)
     result))
 
 (defun psc-ide-parse-imports-in-buffer (&optional buffer)
@@ -335,6 +334,7 @@ use when the search used was with `string-match'."
           ;; Wait for the process in a blocking manner for a maximum of 2
           ;; seconds
           (accept-process-output proc 2)
+          (delete-process proc)
           (json-read-from-string (-first-item (s-lines (buffer-string)))))
       (error
        (error


### PR DESCRIPTION
Just putting this out there. This still needs a little work on windows, but I'm quite happy with how it turned out. 

This gets rid of the `psc-ide-client` usage, and instead opens network connections from inside emacs. This means we get asynchronous commands. I also implemented a blocking synchronous version becasue especially for the file modifying commands we want sequential semantics.

I also removed the response filtering and instead moved that logic into the queries we send to psc-ide. I removed filtering on explicit imports, because with the `add-import` command it's likely the user wants to see not explicitly imported identifiers for modules that he has already imported.

I'd like the adventurous @bsermons and @bodil to give this a try and see if they spot any new bugs, before we merge this in.

This PR builds on top of the nicer errors PR and shouldn't be merged before that one is in.
