### PR TITLE
Added indention to emacs config

### DIFF
--- a/README.org
+++ b/README.org
@@ -27,7 +27,8 @@
      (lambda ()
        (psc-ide-mode)
        (company-mode)
-       (flycheck-mode)))
+       (flycheck-mode)
+       (turn-on-purescript-indentation)))
    #+END_SRC
 
 ** Usage


### PR DESCRIPTION
This was necessary for me in order to prevent emacs-help popups. @kRITZCREEK suggested I open a pull request.