### PR TITLE
Improvements to the rebuild command

### DIFF
--- a/psc-ide.el
+++ b/psc-ide.el
@@ -243,6 +243,7 @@ in a buffer"
 (defun psc-ide-rebuild ()
   "Rebuild the current module"
   (interactive)
+  (save-buffer)
   (psc-ide-send (psc-ide-command-rebuild) 'psc-ide-rebuild-handler))
 
 (defun psc-ide-rebuild-handler (response)
@@ -252,31 +253,27 @@ none."
   (let ((is-success (string= "success" (cdr (assoc 'resultType response))))
         (result (cdr (assoc 'result response))))
     (if (not is-success)
-        ;; Display the first reported error
-        (let* ((first-error (aref result 0)))
-          (psc-ide-display-rebuild-error
-           (psc-ide-pretty-json-error first-error))))
+        (psc-ide-display-rebuild-messages "Error" result))
     (if (<= (length result) 0)
         ;; If there are no warnings we close the rebuild buffer and print "OK"
         (progn
-          (delete-windows-on (get-buffer-create "*psc-ide-rebuild*"))
+          (kill-buffer "*psc-ide-rebuild*")
           (message "OK"))
-      (let ((first-warning (aref result 0)))
-        ;; Display the first reported warning
-        (psc-ide-display-rebuild-error
-         (psc-ide-pretty-json-error first-warning))))))
+      (psc-ide-display-rebuild-messages "Warning" result))))
 
-(defun psc-ide-display-rebuild-error (err)
+(defun psc-ide-display-rebuild-messages (type msgs)
   "Takes a parsed JSON error/warning and displays it in the
 rebuild buffer."
-  (with-current-buffer (get-buffer-create "*psc-ide-rebuild*")
-    (compilation-mode)
-    (read-only-mode -1)
-    (erase-buffer)
-    (insert err)
-    (read-only-mode 1))
-  (display-buffer "*psc-ide-rebuild*")
-  (set-window-point (get-buffer-window "*psc-ide-rebuild*") (point-min)))
+  (let ((msg (mapconcat (lambda (m) (concat type ": " (psc-ide-pretty-json-error m))) msgs "\n\n")))
+    (progn 
+      (with-current-buffer (get-buffer-create "*psc-ide-rebuild*")
+        (compilation-mode)
+        (read-only-mode -1)
+        (erase-buffer)
+        (insert msg)
+        (read-only-mode 1))
+      (display-buffer "*psc-ide-rebuild*")
+      (set-window-point (get-buffer-window "*psc-ide-rebuild*") (point-min)))))
 
 (defun psc-ide-pretty-json-error (err)
   "Formats a parsed JSON error/warning into a format that can be

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -257,7 +257,8 @@ none."
     (if (<= (length result) 0)
         ;; If there are no warnings we close the rebuild buffer and print "OK"
         (progn
-          (kill-buffer "*psc-ide-rebuild*")
+          (if (not (eq nil (get-buffer "*psc-ide-rebuild*")))
+              (kill-buffer "*psc-ide-rebuild*"))
           (message "OK"))
       (psc-ide-display-rebuild-messages "Warning" result))))
 

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -253,19 +253,18 @@ none."
   (let ((is-success (string= "success" (cdr (assoc 'resultType response))))
         (result (cdr (assoc 'result response))))
     (if (not is-success)
-        (psc-ide-display-rebuild-messages "Error" result))
+        (psc-ide-display-rebuild-message "Error" (first-error (aref result 0))))
     (if (<= (length result) 0)
         ;; If there are no warnings we close the rebuild buffer and print "OK"
         (progn
-          (if (not (eq nil (get-buffer "*psc-ide-rebuild*")))
-              (kill-buffer "*psc-ide-rebuild*"))
+          (delete-windows-on (get-buffer-create "*psc-ide-rebuild*"))
           (message "OK"))
-      (psc-ide-display-rebuild-messages "Warning" result))))
+      (psc-ide-display-rebuild-message "Warning" (first-warning (aref result 0))))))
 
-(defun psc-ide-display-rebuild-messages (type msgs)
+(defun psc-ide-display-rebuild-message (type rawMsg)
   "Takes a parsed JSON error/warning and displays it in the
 rebuild buffer."
-  (let ((msg (mapconcat (lambda (m) (concat type ": " (psc-ide-pretty-json-error m))) msgs "\n\n")))
+  (let ((msg (concat type ": " (psc-ide-pretty-json-error rawMsg))))
     (progn 
       (with-current-buffer (get-buffer-create "*psc-ide-rebuild*")
         (compilation-mode)


### PR DESCRIPTION
* save the buffer before rebuild - so that all changes are taken into
  account
* display all errors/warnings, instead of the first one - especially
  with warnings, this is very useful as you don't have to rebuild all
  the time but get a nice list
* prefix warnings/errors with "Warning" or "Error" to specify what the
  message is
* when there are no more errors/warnings, don't close the window, but
  only kill the buffer. The window might have been there before with
  something else.