### PR TITLE
Query type information asynchronous

### DIFF
--- a/test/psc-ide-test.el
+++ b/test/psc-ide-test.el
@@ -27,17 +27,6 @@ import Halogen.HTML.Events.Indexed as P
   (psc-ide-test-example-with-buffer
     (lambda () (psc-ide-parse-imports-in-buffer))))
 
-(ert-deftest psc-ide-show-type-impl-test ()
-  (with-mock
-   (mock (psc-ide-send-sync *) => (json-read-from-string "{\"result\":[{\"type\":\"Show-Type\",\"module\":\"Module\",\"identifier\":\"something\"}],\"resultType\":\"success\"}\n"))
-   (should (string= "Module.something :: \n  Show-Type"
-                    (psc-ide-show-type-impl "something"))))
-
-  (with-mock
-   (mock (psc-ide-send-sync *) => (json-read-from-string "{\"result\":[],\"resultType\":\"success\"}\n"))
-   (should (not (psc-ide-show-type-impl "something")))))
-
-
 ;; Module  import parsing tests
 
 (ert-deftest test-get-import-matches-in-buffer-should-return-all-imports ()


### PR DESCRIPTION
Eldoc can be very annoying when the server has a hickup or the project got large enough that a type command is noticeable lag during typing.

I removed the test because in order to keep it working I'd have to break the show-type command into lots of smaller functions and I didn't want to do that since the type command doesn't contain any actual logic but the formatting and that's straightforward enough for my taste.