### PR TITLE
Use string-to-number instead of obsolete string-to-int

### DIFF
--- a/psc-ide.el
+++ b/psc-ide.el
@@ -403,8 +403,8 @@ use when the search used was with `string-match'."
 (defun psc-ide--version-gte (version1 version2)
   "Determines whether VERSION1 is greater then or equal to VERSION2"
   (let* ((vs (-zip-fill 0
-                        (-map 'string-to-int (s-split "\\." version1))
-                        (-map 'string-to-int (s-split "\\." version2))))
+                        (-map 'string-to-number (s-split "\\." version1))
+                        (-map 'string-to-number (s-split "\\." version2))))
          ;; drop all the prefix version numbers that are equal
          (v (car (--drop-while (= (cdr it) (car it)) vs))))
     ;; if v is nil, the two versions were completely equal


### PR DESCRIPTION
The function `string-to-int` is obsolete and unavailable in development versions of emacs.

See https://www.gnu.org/software/emacs/manual/html_node/elisp/String-Conversion.html