### PR TITLE
replace `psc-ide-server` with `purs ide server`

### DIFF
--- a/README.org
+++ b/README.org
@@ -2,7 +2,7 @@
 
 * psc-ide-emacs
 
-  Emacs integration for [[https://github.com/purescript/purescript/tree/master/psc-ide-server][psc-ide]]
+  Emacs integration for [[https://github.com/purescript/purescript/tree/master/psc-ide][psc-ide]]
 
 ** Installation
 
@@ -32,7 +32,7 @@
    #+END_SRC
 
    If you want to use the psc-ide server that is relative to your `npm bin`
-   directory, e.g. `./node_modules/.bin/psc-ide-server`, add this line to your
+   directory, e.g. `./node_modules/.bin/purs`, add this line to your
    config:
 
    #+BEGIN_SRC elisp

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -384,11 +384,14 @@ use when the search used was with `string-match'."
   "Tries to find the psc-ide executable and builds up the
   command by appending eventual options. Returns a list that can
   be expanded and passed to start-process"
-  (let* ((cmd (psc-ide-executable-name))
+  (let* ((executable-name (psc-ide-executable-name))
          (npm-bin-path (if psc-ide-use-npm-bin
-                           (psc-ide-npm-bin-server-executable cmd)
+                           (psc-ide-npm-bin-server-executable executable-name)
                          nil))
-         (path (or npm-bin-path (executable-find cmd)))
+         (path (or npm-bin-path (executable-find executable-name)))
+         (cmd (if psc-ide-use-purs
+                  `(,path "ide" "server")
+                `(,path)))
          (port (number-to-string psc-ide-port))
          (directory (expand-file-name dir-name))
          (debug-flags (when psc-ide-debug (if psc-ide-use-purs
@@ -399,10 +402,10 @@ use when the search used was with `string-match'."
                                                  "0.9.2"))
                   psc-ide-source-globs)))
     (if path
-        (remove nil `(,path "ide" "server" "-p" ,port "-d" ,directory "--output-directory" ,psc-ide-output-directory ,@debug-flags ,@globs))
+        (remove nil `(,@cmd "-p" ,port "-d" ,directory "--output-directory" ,psc-ide-output-directory ,@debug-flags ,@globs))
       (error (s-join " " '("Couldn't locate psc ide executable. You"
                            "could either customize the psc-ide-server-executable"
-                           " or psc-ide-purs-executable if psc-ide-use-purs is on."
+                           " or psc-ide-purs-executable if psc-ide-use-purs is t."
                            "set the psc-ide-use-npm-bin variable to"
                            "true, or put the executable on your path."))))))
 (defun psc-ide-executable-name ()

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -61,13 +61,13 @@
   :prefix "psc-ide-"
   :group 'psc-ide)
 
-(defcustom psc-ide-server-executable "psc-ide-server"
-  "Path to the 'psc-ide-server' executable."
+(defcustom purs-executable "purs"
+  "Path to the 'purs' executable."
   :group 'psc-ide
   :type  'string)
 
 (defcustom psc-ide-use-npm-bin nil
-  "Whether to use `npm bin` to determine the location of the psc-ide server."
+  "Whether to use `npm bin` to determine the location of the purs ide server."
   :group 'psc-ide
   :type  'boolean)
 
@@ -371,33 +371,34 @@ use when the search used was with `string-match'."
                           ,@(psc-ide-server-command dir-name))))
 
 (defun psc-ide-server-command (dir-name)
-  "Tries to find the psc-ide-server-executable and builds up the
+  "Tries to find the purs executable and builds up the
   command by appending eventual options. Returns a list that can
   be expanded and passed to start-process"
   (let* ((npm-bin-path (if psc-ide-use-npm-bin
                            (psc-ide-npm-bin-server-executable)
                          nil))
-         (path (or npm-bin-path (executable-find psc-ide-server-executable)))
+         (path (or npm-bin-path (executable-find purs-executable)))
          (port (number-to-string psc-ide-port))
          (directory (expand-file-name dir-name))
-         (debug-flag (when psc-ide-debug "--debug"))
-         (globs (when (psc-ide--version-gte (psc-ide-server-version) "0.9.2") psc-ide-source-globs)))
+         (debug-flags (when psc-ide-debug '("--log-level" "debug")))
+         ;; (globs (when (psc-ide--version-gte (psc-ide-server-version) "0.9.2") psc-ide-source-globs))
+         )
     (if path
-        (remove nil `(,path "-p" ,port "-d" ,directory "--output-directory" ,psc-ide-output-directory ,debug-flag ,@globs))
-      (error (s-join " " '("Couldn't locate the psc-ide-server executable. You"
-                           "could either customize the psc-ide-server-executable"
+        (remove nil `(,path "ide" "server" "-p" ,port "-d" ,directory "--output-directory" ,psc-ide-output-directory ,@debug-flags))
+      (error (s-join " " '("Couldn't locate the purs executable. You"
+                           "could either customize the purs-executable"
                            "setting, or set the psc-ide-use-npm-bin variable to"
                            "true, or put the executable on your path."))))))
 
 (defun psc-ide-npm-bin-server-executable ()
   "Find psc-ide-server binary of current project by invoking `npm bin`"
   (let* ((npm-bin (s-trim-right (shell-command-to-string "npm bin")))
-         (server (expand-file-name psc-ide-server-executable npm-bin)))
+         (server (expand-file-name purs-executable npm-bin)))
     (if (and server (file-executable-p server)) server nil)))
 
 (defun psc-ide-server-version ()
   "Returns the version of the found psc-ide-server executable"
-  (let ((path (executable-find psc-ide-server-executable)))
+  (let ((path (executable-find purs-executable)))
     (s-chomp (shell-command-to-string (s-concat path " --version")))))
 
 (defun psc-ide--version-gte (version1 version2)

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -76,8 +76,8 @@
   :group 'psc-ide
   :type  'boolean)
 
-(defcustom psc-ide-use-purs nil
-  "Whether to use `purs ide' to start psc ide server"
+(defcustom psc-ide-use-purs t
+  "Whether to use `purs ide' to start psc ide server, if nil fallback to use old psc-ide-server"
   :group 'psc-ide
   :type 'boolean)
 
@@ -396,18 +396,14 @@ use when the search used was with `string-match'."
          (directory (expand-file-name dir-name))
          (debug-flags (when psc-ide-debug (if psc-ide-use-purs
                                               '("--log-level" "debug")
-                                            '("--debug"))))
-         (globs (when (and (not psc-ide-use-purs)
-                           (psc-ide--version-gte (psc-ide-server-version)
-                                                 "0.9.2"))
-                  psc-ide-source-globs)))
+                                            '("--debug")))))
     (if path
-        (remove nil `(,@cmd "-p" ,port "-d" ,directory "--output-directory" ,psc-ide-output-directory ,@debug-flags ,@globs))
+        (remove nil `(,@cmd "-p" ,port "-d" ,directory "--output-directory" ,psc-ide-output-directory ,@debug-flags ,@psc-ide-source-globs))
       (error (s-join " " '("Couldn't locate psc ide executable. You"
-                           "could either customize the psc-ide-server-executable"
-                           " or psc-ide-purs-executable if psc-ide-use-purs is t."
-                           "set the psc-ide-use-npm-bin variable to"
-                           "true, or put the executable on your path."))))))
+                           "could either customize the psc-ide-purs-executable"
+                           " or psc-ide-server-executable if psc-ide-use-purs is nil,"
+                           " or set the psc-ide-use-npm-bin variable to"
+                           " true, or put the executable on your path."))))))
 (defun psc-ide-executable-name ()
   "Find ide executable name"
   (if psc-ide-use-purs


### PR DESCRIPTION
[psc-ide](https://github.com/kRITZCREEK/psc-ide) is deprecated.
#95 