### PR TITLE
Shows the qualifier for completions, if they've already been imported qualified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG
 
+## 2017-04-20
+- Displays completions with their already imported qualifiers. This can be toggled
+off with `(setq psc-ide-add-qualification-on-completion nil)`.
+
+- Displays the result of the load command in the message buffer
+
 ## 2017-04-18
-Switched to purescrpt-0.11 compatible `purs` executable by default. The 0.10
+- Switched to purescript-0.11 compatible `purs` executable by default. The 0.10
 binaries can be regained with `(setq psc-ide-use-purs nil)`, but we'll remove
 this switch when purescript-0.12 is released.

--- a/psc-ide-protocol.el
+++ b/psc-ide-protocol.el
@@ -122,6 +122,14 @@ Evaluates the CALLBACK in the context of the CURRENT buffer that initiated call 
    (list :command "rebuild"
          :params (list
                   :file (or filepath (buffer-file-name (current-buffer)))))))
+
+(defun psc-ide-command-list-imports (&optional filepath)
+  (json-encode
+   (list :command "list"
+         :params (list
+                  :type "import"
+                  :file (or filepath (buffer-file-name (current-buffer)))))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; Protocol utilities.

--- a/test/psc-ide-test.el
+++ b/test/psc-ide-test.el
@@ -40,7 +40,7 @@ import Halogen.HTML.Events.Indexed as P
     (string-match psc-ide-import-regex import)
     (let* ((import (psc-ide-extract-import-from-match-data import)))
       (should (equal (assoc 'module import) (cons 'module name)))
-      (should (equal (assoc 'alias import) (cons 'alias as)))))
+      (should (equal (assoc 'qualifier import) (cons 'qualifier as)))))
 
 (ert-deftest test-get-import-from-match-data-full ()
   (test-import "import Mod.SubMod (foo, bar) as El"
@@ -50,7 +50,7 @@ import Halogen.HTML.Events.Indexed as P
 (ert-deftest test-match-import-single-module ()
   (test-import "import Foo" "Foo" nil))
 
-(ert-deftest test-match-import-with-alias ()
+(ert-deftest test-match-import-with-qualifier ()
   (test-import "import Foo as F" "Foo" "F"))
 
 (ert-deftest test-match-import-with-single-expose ()
@@ -62,10 +62,10 @@ import Halogen.HTML.Events.Indexed as P
 (ert-deftest test-match-import-with-multiple-exposings-loose ()
   (test-import "import Foo ( test1 , test2 )" "Foo" nil))
 
-(ert-deftest test-match-import-with-alias+multiple-exposings-tight ()
+(ert-deftest test-match-import-with-qualifier+multiple-exposings-tight ()
   (test-import "import Foo (test1,test2) as F" "Foo" "F"))
 
-(ert-deftest test-match-import-with-alias+multiple-exposings-loose ()
+(ert-deftest test-match-import-with-qualifier+multiple-exposings-loose ()
   (test-import
    "import Foo ( test1 , test2 ) as F"
    "Foo"
@@ -76,9 +76,9 @@ import Halogen.HTML.Events.Indexed as P
                    (lambda () (psc-ide-all-imported-modules)))))
     (should (equal (length imports) 10))))
 
-(ert-deftest test-moduels-for-alias ()
+(ert-deftest test-moduels-for-qualifier ()
   (let ((imports (psc-ide-test-example-with-buffer
-                   (lambda () (psc-ide-modules-for-alias "P")))))
+                   (lambda () (psc-ide-modules-for-qualifier "P")))))
     (should (equal (length imports) 2))))
 
 (ert-deftest test-get-completion-settings ()


### PR DESCRIPTION
A GIF speaks a thousand words:

![qualified-completion](https://cloud.githubusercontent.com/assets/6189397/25218958/f799f252-25ac-11e7-9603-49bb89035efd.gif)

This also stops the completion from adding imports. The behaviour can be toggled with the `psc-ide-add-qualification-on-completion` variable.

This PR also contains two small unrelated changes, where one is the addition of the `list import` command for purs ide, and the other one is to display the results of the loading command.