### PR TITLE
add qualified imports

### DIFF
--- a/psc-ide-protocol.el
+++ b/psc-ide-protocol.el
@@ -117,6 +117,17 @@ Evaluates the CALLBACK in the context of the CURRENT buffer that initiated call 
                                   :importCommand "addImport"
                                   :identifier identifier)))))
 
+(defun psc-ide-command-add-qualified-import (modulename qualifier &optional file outfile)
+  (json-encode
+   (list :command "import"
+         :params (list
+                  :file (or file (buffer-file-name))
+                  :outfile (or outfile (buffer-file-name))
+                  :importCommand (list
+                                  :importCommand "addQualifiedImport"
+                                  :module modulename
+                                  :qualifier qualifier)))))
+
 (defun psc-ide-command-rebuild (&optional filepath)
   (json-encode
    (list :command "rebuild"

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -503,10 +503,8 @@ doesn't contain eventual qualifiers."
          (qualifier (s-join "." (butlast splitted)))
          (identifier (-last-item splitted)))
     (when (and identifier (s-uppercase? (substring qualifier 0 1)))
-      (let (table)
-        (push (cons 'identifier identifier) table)
-        (push (cons 'qualifier qualifier) table)
-        table))))
+      `((identifier . ,identifier)
+        (qualifier . ,qualifier)))))
 
 (defun psc-ide-build-completion-command (search manual)
   "Constructs a completion command from the given SEARCH.

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -502,7 +502,7 @@ doesn't contain eventual qualifiers."
   (let* ((splitted (s-split "\\." s))
          (qualifier (s-join "." (butlast splitted)))
          (identifier (-last-item splitted)))
-    (when (and identifier (s-uppercase? (substring qualifier 0 1)))
+    (when (and identifier (not (string= "" qualifier)) (s-uppercase? (substring qualifier 0 1)))
       `((identifier . ,identifier)
         (qualifier . ,qualifier)))))
 


### PR DESCRIPTION
Only works with the current PS master, but as soon as a new release is cut this'll work. When invoking the add import command on a qualified identifier, we now suggest modules to import under that qualifier.

![mandatory gif](http://i.imgur.com/n79PSFe.gif)