### PR TITLE
Make dependency files read only

### DIFF
--- a/psc-ide.el
+++ b/psc-ide.el
@@ -599,6 +599,11 @@ PARSED-IMPORTS are used to annotate the COMPLETION with qualifiers."
                   (require 'etags)
                   (ring-insert find-tag-marker-ring (point-marker))))
               (find-file (expand-file-name file))
+	      (unless (boundp 'projectile-project-root)
+		(let ((dependency-root
+		       (concat (projectile-project-root) "bower_components")))
+		  (unless (string-prefix-p dependency-root (buffer-file-name))
+		    (toggle-read-only))))
               (goto-char (point-min))
               (forward-line (1- line))
               (forward-char (1- column)))


### PR DESCRIPTION
This PR makes it such that if goto definition jumps to a file in the bower_components directory, then it will toggle the mode to read-only.

I'm not entirely sure whether this works for all types of projects or whether there's a better way of doing this since I don't have a particularly big purescript code base.