### PR TITLE
Editor mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 2017-11-22 Adds `psc-ide-editor-mode` variable
+This sets the --editor-mode flag on the server executable if set to true. It
+defaults to false for backwards compatibility, but will default to true in a
+while
+
 ## 2017-08-17
 - Added a LICENSE file and the appropriate headers
 

--- a/psc-ide-flycheck.el
+++ b/psc-ide-flycheck.el
@@ -124,7 +124,7 @@ CALLBACK is the status callback passed by flycheck."
 
   (let ((temp-file (flycheck-save-buffer-to-temp #'flycheck-temp-file-system)))
     (psc-ide-flycheck-copy-related-files (buffer-file-name) temp-file)
-    (psc-ide-send (psc-ide-command-rebuild temp-file)
+    (psc-ide-send (psc-ide-command-rebuild temp-file (buffer-file-name))
                   (lambda (result)
                     (condition-case err
                         (progn

--- a/psc-ide-protocol.el
+++ b/psc-ide-protocol.el
@@ -136,11 +136,12 @@ Evaluates the CALLBACK in the context of the CURRENT buffer that initiated call 
                                   :module modulename
                                   :qualifier qualifier)))))
 
-(defun psc-ide-command-rebuild (&optional filepath)
+(defun psc-ide-command-rebuild (&optional filepath actualFile)
   (json-encode
    (list :command "rebuild"
-         :params (list
-                  :file (or filepath (buffer-file-name (current-buffer)))))))
+         :params (-filter #'identity
+                          `(,@(list :file (or filepath (buffer-file-name)))
+                            ,@(when actualFile (list :actualFile actualFile)))))))
 
 (defun psc-ide-command-list-imports (&optional filepath)
   (json-encode

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -131,6 +131,11 @@ Defaults to \"output/\" and should only be changed with
   :group 'psc-ide
   :type  'boolean)
 
+(defcustom psc-ide-editor-mode nil
+  "Whether to only reload files when the editor initiates rebuilds."
+  :group 'psc-ide
+  :type 'boolean)
+
 (defcustom psc-ide-server-extra-args nil
   "Extra arguments to pass to the purs ide executable."
   :group 'psc-ide
@@ -403,10 +408,12 @@ and passed to `start-process`."
          (directory (expand-file-name dir-name))
          (debug-flags (when psc-ide-debug (if psc-ide-use-purs
                                               '("--log-level" "debug")
-                                            '("--debug")))))
+                                            '("--debug"))))
+         (editor-mode (when psc-ide-editor-mode '("--editor-mode"))))
     (if path
         (remove nil `(,@cmd "-p" ,port "-d" ,directory
                             "--output-directory" ,psc-ide-output-directory
+                            ,@editor-mode
                             ,@debug-flags ,@psc-ide-server-extra-args
                             ,@psc-ide-source-globs))
       (error (s-join " " '("Couldn't locate psc ide executable. You"

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -629,7 +629,7 @@ on whether WARN is true. Optionally EXPANDs type synonyms."
              (if (not (zerop (length result)))
                (let-alist (aref result 0)
                  (message (psc-ide-string-fontified
-                           (format "%s.%s ::\n  %s"
+                           (format "%s.%s ∷\n  %s"
                                    .module
                                    .identifier
                                    (if expand .expandedType .type)))))


### PR DESCRIPTION
Adds the necessary flags and parameters for `--editor-mode`, which will be in the next compiler release.

It's turned off by default, in order to not break existing setups. I haven't added any documentation yet, but I intend to give the README a major rewriting anyway, so I figured I'd group that work.

I've tested this, but I invite anyone to try this with the current PureScript master. The main benefit is that we don't rely on watching the output directory anymore. This means more reliable reloads on Linux, and less idle CPU usage on Windows (because of no polling). It also means source locations get refreshed whenever a file succesfully gets rebuilt.
