### PR TITLE
Add support for psc-package

### DIFF
--- a/psc-ide.el
+++ b/psc-ide.el
@@ -88,7 +88,7 @@
   :group 'psc-ide
   :type  'integer)
 
-(defcustom psc-ide-source-globs '("src/**/*.purs" "bower_components/purescript-*/src/**/*.purs")
+(defcustom psc-ide-source-globs '("src/**/*.purs" "bower_components/purescript-*/src/**/*.purs" ".psc-package/**/*.purs")
   "The source globs for your PureScript source files."
   :group 'psc-ide
   :type  'sexp)


### PR DESCRIPTION
Currently if the server is started from emacs with a project that uses psc-package rather than bower it fails to load the modules downloaded by psc-packge. This is caused by `psc-ide-src-globs`. I do not know if my glob might affect performance.