### PR TITLE
Better handling for identifiers with dot's

### DIFF
--- a/psc-ide-backported.el
+++ b/psc-ide-backported.el
@@ -21,13 +21,16 @@ May return a qualified name."
 
     (let ((case-fold-search nil))
       (cl-multiple-value-bind (start end)
-          (if (looking-at "\\s_|\.")
-              (list (progn (skip-syntax-backward "_") (point))
-                    (progn (skip-syntax-forward "_") (point)))
-            (list
-             (progn (skip-syntax-backward "w'")
-                    (skip-syntax-forward "'") (point))
-             (progn (skip-syntax-forward "w'") (point))))
+          (if (looking-at "\\.")
+              (list (progn (skip-syntax-backward "w_") (point))
+                    (progn (skip-syntax-forward "w_") (point)))
+            (if (looking-at "\\s_")
+                (list (progn (skip-syntax-backward "_") (point))
+                      (progn (skip-syntax-forward "_") (point)))
+              (list
+               (progn (skip-syntax-backward "w'")
+                      (skip-syntax-forward "'") (point))
+               (progn (skip-syntax-forward "w'") (point)))))
         ;; If we're looking at a module ID that qualifies further IDs, add
         ;; those IDs.
         (goto-char start)

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -649,7 +649,7 @@ on whether WARN is true. Optionally EXPANDs type synonyms."
     (psc-ide-command-show-type
      (vector (psc-ide-filter-modules
               (cons "Prim" (psc-ide-all-imported-modules))))
-     ident
+     search
      (psc-ide-get-module-name)))))
 
 (defun psc-ide-qualified-type-command (ident qualifier)


### PR DESCRIPTION
This attempts to fix my commit that broke operator imports identified in #132 

The `psc-ide-build-type-command` function was also removing the leading dot for operators like `.>`, which seems to be fixed here so hopefully I didn't break anything with that change.

