### PR TITLE
add completion importing the completed module at an unknown qualifier

### DIFF
--- a/psc-ide.el
+++ b/psc-ide.el
@@ -522,10 +522,16 @@ and passed to `start-process`."
             (`1 (cdr (assoc 'module (aref completions 0))))
             (_ (completing-read "Which Module: "
                                 (seq-map (lambda (x) (let-alist x .module)) completions))))))
-    (unless (string= (psc-ide-qualifier-for-module module) qualifier)
-      (save-buffer)
-      (psc-ide-send-sync (psc-ide-command-add-qualified-import module qualifier))
-      (revert-buffer nil t))))
+    (psc-ide-add-import-qualified-impl-write-buffer module qualifier)))
+
+(defun psc-ide-add-import-qualified-impl-write-buffer (module qualifier)
+  "finish the qualified import process for a specified module and qualifier.
+  if `psc-ide-qualifier-for-module` comes back with the qualifier exsting, do nothing.
+"
+  (unless (string= (psc-ide-qualifier-for-module module) qualifier)
+    (save-buffer)
+    (psc-ide-send-sync (psc-ide-command-add-qualified-import module qualifier))
+    (revert-buffer nil t)))
 
 (defun psc-ide-company-fetcher (ignored &optional manual)
   "Create an asynchronous company fetcher.

--- a/psc-ide.el
+++ b/psc-ide.el
@@ -169,6 +169,9 @@ Defaults to \"output/\" and should only be changed with
 
 ;; Interactive.
 
+;; global state for unqualified import
+(setq unqualified-import-completion-qualifier nil)
+
 (add-hook 'after-save-hook
           (lambda ()
             (set 'psc-ide-buffer-import-list
@@ -231,13 +234,20 @@ Defaults to \"output/\" and should only be changed with
        (unless (or
                 ;; Don't add an import when the option to do so is disabled
                 (not psc-ide-add-import-on-completion)
-                ;; or when a qualified identifier was completed
-                (or (get-text-property 0 :qualifier arg) (s-contains-p "." (company-grab-symbol)))
                 ;; Don't attempt to import Prim members
                 (string= (get-text-property 0 :module arg) "Prim"))
-         (psc-ide-add-import-impl arg (vector
-                                       (psc-ide-filter-modules
-                                        (list (get-text-property 0 :module arg))))))))))
+         (if (not (null unqualified-import-completion-qualifier))
+             (progn
+               ;; we know we need to import qualified at this point because we
+               ;; have come from psc-ide-unqualified-completion-command
+               (psc-ide-add-import-qualified-impl-write-buffer (get-text-property 0 :module arg)
+                                                               unqualified-import-completion-qualifier)
+               (setq unqualified-import-completion-qualifier nil))
+           ;; import as usual if we are not completing a qualified import
+           (unless (or (get-text-property 0 :qualifier arg) (s-contains-p "." (company-grab-symbol)))
+             (psc-ide-add-import-impl arg (vector
+                                           (psc-ide-filter-modules
+                                            (list (get-text-property 0 :module arg))))))))))))
 
 (defun psc-ide-server-start (root)
   "Start 'psc-ide-server' in DIR-NAME and load all modules."
@@ -579,20 +589,22 @@ If MANUAL is set, ignore the currently imported modules.
 
 The cases we have to cover:
 1. List.fil      <- filter by prefix and List module
+1a. List.fil     <- where `List` is not yet imported
 2. fil| + manual <- don't filter at all
 3. fil|          <- filter by prefix and imported modules"
   (let* ((components (s-split "\\." search))
          (prefix (car (last components)))
          (qualifier (s-join "." (butlast components))))
     (if (not (s-blank? qualifier))
-        ;; 1. List.fil <- filter by prefix and List module
-        (psc-ide-qualified-completion-command prefix qualifier)
+        (let ((modules (psc-ide-modules-for-qualifier qualifier)))
+          (if (not (null modules))
+              ;; 1. List.fil <- filter by prefix and List module
+              (psc-ide-qualified-completion-command modules prefix qualifier)
+            ;; 1a. List.fil     <- where `List` is not yet imported
+            (psc-ide-unqualified-completion-command prefix qualifier)))
       (if manual
           ;; 2. fil| + manual <- don't filter at all
-          (psc-ide-command-complete
-           (vector (psc-ide-filter-prefix prefix))
-           nil
-           (psc-ide-get-module-name))
+          (psc-ide-import-from-all-completion-command prefix)
         ;; 3. fil| <- filter by prefix and imported modules"
         (psc-ide-command-complete
          (vector (psc-ide-filter-prefix prefix)
@@ -600,14 +612,26 @@ The cases we have to cover:
          nil
          (psc-ide-get-module-name))))))
 
-(defun psc-ide-qualified-completion-command (prefix qualifier)
-  "Build a completion command for a PREFIX with QUALIFIER."
-  (let ((modules (psc-ide-modules-for-qualifier qualifier)))
-    (psc-ide-command-complete
-     (vector (psc-ide-filter-prefix prefix)
-             (psc-ide-filter-modules (vconcat modules)))
-     nil
-     (psc-ide-get-module-name))))
+(defun psc-ide-import-from-all-completion-command (prefix)
+  "Build a completion command for a PREFIX for all available modules."
+  (psc-ide-command-complete
+   (vector (psc-ide-filter-prefix prefix))
+   nil
+   (psc-ide-get-module-name)))
+
+(defun psc-ide-unqualified-completion-command (prefix qualifier)
+  "Build a completion command for a PREFIX with QUALIFIER that is not imported yet."
+  ;; set that we have started an unqualified import completion
+  (setq unqualified-import-completion-qualifier qualifier)
+  (psc-ide-import-from-all-completion-command prefix))
+
+(defun psc-ide-qualified-completion-command (modules prefix qualifier)
+  "Build a completion command with some MODULES for a PREFIX with QUALIFIER."
+  (psc-ide-command-complete
+   (vector (psc-ide-filter-prefix prefix)
+           (psc-ide-filter-modules (vconcat modules)))
+   nil
+   (psc-ide-get-module-name)))
 
 (defun psc-ide-all-imported-modules ()
   "Retrieve all imported modules for a buffer."


### PR DESCRIPTION
Allows for completing with qualified imports where the qualifier is not yet
a qualifier for an import

also splits add psc-ide-add-import-qualified-impl-write-buffer to own function