### PR TITLE
More robust code for extracting psc-package sources

### DIFF
--- a/psc-ide.el
+++ b/psc-ide.el
@@ -253,26 +253,31 @@ Defaults to \"output/\" and should only be changed with
   (psc-ide-send-sync psc-ide-command-quit))
 
 (defun psc-ide--server-start-globs ()
-  "Detects bower and psc-package projects and determines sensible
-  source globs"
+  "Detects bower and psc-package projects and determines sensible source globs."
 
   (when (and (file-exists-p "psc-package.json") (file-exists-p "bower.json"))
     (message "Detected both a \"psc-package.json\" and a \"bower.json\" file."))
 
   (let ((server-globs psc-ide-source-globs))
     (if (file-exists-p "psc-package.json")
-        (let* ((results "*PSC-PACKAGE SOURCES*")
-               (errors "*PSC-PACKAGE ERRORS*"))
-          (shell-command "psc-package sources" results errors)
-          (if (get-buffer errors)
-              (switch-to-buffer-other-window errors)
-            (progn
-              (with-current-buffer (get-buffer-create results)
-                (let* ((globs (split-string (buffer-string))))
-                  (setq server-globs (append server-globs globs))
-                  (delete-windows-on results)
-                  (kill-buffer results)))
-              (message "Set source globs from psc-package. Starting server..."))))
+        (let ((results "*PSC-PACKAGE SOURCES*")
+              (err-file (make-temp-file "psc-package-errs")))
+          (unwind-protect
+              (if (zerop (call-process "psc-package" nil (list results err-file) nil "sources"))
+                  (progn
+                    (with-current-buffer (get-buffer results)
+                      (let ((globs (split-string (buffer-string) "[\r\n]+" t)))
+                        (setq server-globs (append server-globs globs))
+                        (delete-windows-on results)
+                        (kill-buffer results)))
+                    (message "Set source globs from psc-package. Starting server..."))
+                (with-current-buffer (get-buffer-create "*PSC-PACKAGE ERRORS*")
+                  (let ((inhibit-read-only t))
+                    (insert-file-contents err-file nil nil nil t))
+                  (special-mode)
+                  (display-buffer (current-buffer))
+                  (error "Error executing psc-package")))
+            (delete-file err-file)))
       (if (file-exists-p "bower.json")
           (setq server-globs (append server-globs '("bower_components/purescript-*/src/**/*.purs")))
         (message "Couldn't find psc-package.json nor bower.json files, using just the user specified globs.")))


### PR DESCRIPTION
I tried setting up a project with psc-package, and found some issues with psc-ide-emacs' recently-added support (thanks!) for detecting psc-package source globs. Here are some little fixes:

- Use call-process instead of shell-command, so that Emacs' exec-path is used (this allows Emacs packages like `add-node-modules-path` to find `psc-package` if it was installed via `npm`)
- Don't split the glob list on spaces, which would break when directory paths contain spaces
- When psc-package.json exists and psc-package can't be executed successfully, raise an error instead of failing silently
- Reformat docstring to satisfy checkdoc