### PR TITLE
Handle rebuild-on-save more conventionally

### DIFF
--- a/psc-ide.el
+++ b/psc-ide.el
@@ -54,8 +54,11 @@
             (define-key map (kbd "M-.") 'psc-ide-goto-definition)
             (define-key map (kbd "M-,") 'pop-tag-mark)
             map)
-  (when psc-ide-mode
-    (setq-local company-tooltip-align-annotations t)))
+  (if psc-ide-mode
+      (progn
+        (setq-local company-tooltip-align-annotations t)
+        (add-hook 'after-save-hook 'psc-ide-rebuild-on-save-hook nil t))
+    (remove-hook 'after-save-hook 'psc-ide-rebuild-on-save-hook t)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
@@ -174,11 +177,8 @@ Defaults to \"output/\" and should only be changed with
 
 (defun psc-ide-rebuild-on-save-hook()
   "Rebuilds the current module on save."
-  (when (eq major-mode 'purescript-mode)
+  (when psc-ide-rebuild-on-save
     (psc-ide-rebuild)))
-
-(when psc-ide-rebuild-on-save
-  (add-hook 'after-save-hook 'psc-ide-rebuild-on-save-hook))
 
 (defun psc-ide-init ()
   "Initialization for psc-ide-mode."


### PR DESCRIPTION
Don't make a single global decision about whether to do this based on the value of psc-ide-rebuild-on-save at the time the library is loaded.

Instead, add after-save-hook handlers locally to each buffer in which psc-ide-mode is enabled, and then check psc-ide-rebuild-on-save each time.

This way, psc-ide-rebuild-on-save can be set on a per-file or per-directory basis, and no check for the current major mode is necessary.

See #151 and #152