### PR TITLE
adds goto definition based on xref

### DIFF
--- a/psc-ide.el
+++ b/psc-ide.el
@@ -810,7 +810,7 @@ on whether WARN is true.  Optionally EXPANDs type synonyms."
   nil)
 
 (cl-defmethod xref-backend-definitions ((_backend (eql psc-ide)) _symbol)
-  nil)
+  (psc-ide-goto-definition))
 
 (cl-defmethod xref-backend-references ((_backend (eql psc-ide)) symbol)
   (let* ((usages (psc-ide-find-usages symbol))


### PR DESCRIPTION
This means `g d` in evil-mode now works in PureScript files by default. It'll likely also integrate better with other plugins, as xref is pretty standard these days.
